### PR TITLE
build: use pnpm ecosystem instead of npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
+      interval: "monthly"
+  - package-ecosystem: "pnpm"
     directory: "/"
     schedule:
-      interval: "weekly"
-    versioning-strategy: "increase-if-necessary"
+      interval: "monthly"
     open-pull-requests-limit: 20
     reviewers:
       - "nl-design-system/kernteam-dependabot"


### PR DESCRIPTION
Remove increase-if-necessary setting because all versions are pinned anyway.