### PR TITLE
feat: deploy GitHub pages via actions

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -6,6 +6,15 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   install:
     name: Install dependencies
@@ -13,20 +22,20 @@ jobs:
 
     steps:
       - name: Download code from GitHub
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies specified in package.json
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm ls --recursive
 
   lint:
@@ -36,24 +45,22 @@ jobs:
 
     steps:
       - name: Download code from GitHub
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies specified in package.json
-        run: |
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run the lint script in package.json scripts
-        run: |
-          pnpm run --if-present lint
+        run: pnpm run --if-present lint
 
   build:
     name: Build
@@ -62,116 +69,43 @@ jobs:
 
     steps:
       - name: Download code from GitHub
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5.0.0
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies specified in package.json
-        run: |
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run the build script in package.json scripts
         env:
           BASE_URL: "/gebruikersonderzoeken/"
-        run: |
-          pnpm run --if-present build
+        run: pnpm run --if-present build
 
       - name: Upload the results from the build step
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
-          name: website
           path: build/
-          retention-days: 1
 
   publish-website:
     name: Publish website
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-pages.outputs.page_url }}
 
     steps:
-      - name: Download code from GitHub
-        uses: actions/checkout@v4.1.2
-
-      - name: Download the results from the "Build" job
-        uses: actions/download-artifact@v4.1.4
-        with:
-          name: website
-          path: build/
-
-      - name: Continuous Deployment to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
-        with:
-          branch: gh-pages
-          folder: build/
-
-  # publish-npm:
-  #   runs-on: ubuntu-latest
-  #   needs: [lint, test]
-  #   if: github.ref == 'refs/heads/main'
-
-  #   steps:
-  #     - name: Checkout release branch
-  #       uses: actions/checkout@v3
-  #       with:
-  #         token: ${{ secrets.GH_TOKEN }}
-
-  #     - name: Set up Node.js version
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: "18.14.x"
-
-  #     - uses: pnpm/action-setup@v2.0.1
-  #       name: Install pnpm
-  #       id: pnpm-install
-  #       with:
-  #         version: 7
-  #         run_install: false
-
-  #     - name: Get pnpm store directory
-  #       id: pnpm-cache
-  #       run: |
-  #         echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
-
-  #     - uses: actions/cache@v3
-  #       name: Setup pnpm cache
-  #       with:
-  #         path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-  #         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-pnpm-store-
-
-  #     - name: "Continuous Deployment: install"
-  #       run: |
-  #         pnpm install
-  #         pnpm ls --recursive
-
-  #     - name: "Continuous Deployment: build"
-  #       run: |
-  #         pnpm run --if-present build
-
-  #     - name: "Continuous Deployment: publish to GitHub repository"
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-  #         GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
-  #         GIT_AUTHOR_NAME: "NL Design System"
-  #         GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}
-  #         GIT_COMMITTER_NAME: "NL Design System"
-  #       run: |
-  #         git push --set-upstream origin HEAD
-  #         pnpm run release
-
-  #     - name: "Continuous Deployment: publish to npm"
-  #       env:
-  #         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  #       run: |
-  #         pnpm config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
-  #         pnpm run publish
-  #         pnpm config delete "//registry.npmjs.org/:_authToken"
+      - name: Deploy
+        id: deploy-pages
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
- Use GitHub's own `actions/upload-pages-artifact` and `actions/deploy-pages` actions
-  Update actions to their latest versions using hashes to prevent tampering, the tags are added as comments. Dependabot will honour this format