### PR TITLE
Tagline aanpassing

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,7 +12,7 @@ function HomepageHeader() {
       <div className="container">
         <h1 className="hero__title">Gebruikersonderzoeken</h1>
         <p>
-          Hier verzamelen en delen we zoveel mogelijk gebruikersonderzoeken van alle gemeenten in Nederland voor
+          Hier verzamelen en delen we zoveel mogelijk gebruikersonderzoeken van alle overheidsinstanties in Nederland voor
           onderzoekers, ontwerpers en managers. Zodat we zoveel mogelijk van elkaar kunnen leren, geinspireerd raken
           door elkaar's onderzoek en sneller de juiste beslissingen kunnen nemen.
         </p>


### PR DESCRIPTION
Tagline aanpassing zodat er niet 'gemeentes' staat maar 'overheidsinstanties', zodat bijvoorbeeld RVO zich ook betrokken voelt.