### PR TITLE
build: add vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "assets": false
+    }
+  }
+}


### PR DESCRIPTION
Make Vercel ignore commits to the `assets` branch becaus that branch only contains assets and nothing that could be built.