### PR TITLE
fix: broaden package.json#engines.node range

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     ]
   },
   "engines": {
-    "//": "Update @types/node when updating the node version here",
-    "node": "^22",
+    "//": "Update @types/node to match the highest node version here",
+    "node": ">=20 <=22",
     "pnpm": "^9"
   },
   "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"


### PR DESCRIPTION
Dependabot uses the package.json#engines.node field to determine the Node.js version to use. It currently does not work with Node.js 22 so allow Node.js 20 as well.