### PR TITLE
chore:change e-mail for yolijn

### DIFF
--- a/docs/onderzoek-delen/README.md
+++ b/docs/onderzoek-delen/README.md
@@ -13,14 +13,14 @@ keywords:
 
 # Gebruikersonderzoeken delen
 
-Het plaatsen van onderzoek op de site hebben we zo laagdrempelig mogelijk gemaakt. Mocht er iets onduidelijk zijn, [neem contact met ons op](mailto:j.du.chatinier@utrecht.nl,yolijn@frameless.io).
+Het plaatsen van onderzoek op de site hebben we zo laagdrempelig mogelijk gemaakt. Mocht er iets onduidelijk zijn, [neem contact met ons op](mailto:j.du.chatinier@utrecht.nl,info@nldesignsystem.nl).
 
 ## Onderzoek op deze site plaatsen
 
 Er zijn verschillende manieren om onderzoek op de site te (laten) plaatsen:
 
 - Maak een [issue](https://github.com/nl-design-system/gebruikersonderzoeken/issues) aan op onze github en voeg je onderzoek daar aan toe.
-- [Stuur ons een mailtje met je onderzoek](mailto:j.du.chatinier@utrecht.nl,yolijn@frameless.io).
+- [Stuur ons een mailtje met je onderzoek](mailto:j.du.chatinier@utrecht.nl,info@nldesignsystem.nl).
 - Als je handig bent met gitHub: [maak een Pull-request in onze gitHub](https://github.com/nl-design-system/gebruikersonderzoeken/) waar je onderzoek in staat.
 
 ## In wat voor type bestand lever ik het onderzoek aan?
@@ -40,7 +40,7 @@ We knippen het onderzoek zo op dat het dezelfde structuur aanhoudt als ons templ
 Een bestaand onderzoek kan je altijd aanpassen, op de volgende drie manieren:
 
 - Maak een [issue](https://github.com/nl-design-system/gebruikersonderzoeken/issues) aan op onze gitHub en voeg je gewenste wijzigingen daar aan toe.
-- [Stuur ons een mailtje met je wijzigingen](mailto:j.du.chatinier@utrecht.nl,yolijn@frameless.io).
+- [Stuur ons een mailtje met je wijzigingen](mailto:j.du.chatinier@utrecht.nl,info@nldesignsystem.nl).
 - Als je handig bent met gitHub: [maak een Pull-request in onze gitHub](https://github.com/nl-design-system/gebruikersonderzoeken/) waar je wijzigingen in staan.
 
 ## Eisen aan het onderzoek

--- a/docs/vragen/README.md
+++ b/docs/vragen/README.md
@@ -13,7 +13,7 @@ keywords:
 
 # Vragen
 
-We proberen zo veel mogelijk vragen over deze pagina hier te beantwoorden. Mocht je vraag hier niet beantwoord worden, [neem contact met ons op](mailto:j.du.chatinier@utrecht.nl,yolijn@frameless.io).
+We proberen zo veel mogelijk vragen over deze pagina hier te beantwoorden. Mocht je vraag hier niet beantwoord worden, [neem contact met ons op](mailto:j.du.chatinier@utrecht.nl,info@nldesignsystem.nl).
 
 ## Hoe deel ik mijn onderzoek op deze site?
 
@@ -23,7 +23,7 @@ Hoe je dat moet doen leggen we uit op onze [Onderzoek delen pagina](../onderzoek
 
 Elk gedeeld onderzoek heeft contactgegevens van de onderzoekers en de persoon die het onderzoek heeft gepubliceerd. Zo kun je makkelijk de juiste persoon te pakken krijgen.
 
-Mocht je een opmerking hebben of onderzoek hebben wat erop lijkt, [neem contact met ons op](mailto:j.du.chatinier@utrecht.nl,yolijn@frameless.io).
+Mocht je een opmerking hebben of onderzoek hebben wat erop lijkt, [neem contact met ons op](mailto:j.du.chatinier@utrecht.nl,info@nldesignsystem.nl).
 
 ## Waarom deze site?
 
@@ -37,8 +37,8 @@ Voor iedereen die gebruikersonderzoeken interessant vindt. In eerste instantie r
 
 ## Wie houdt deze site bij?
 
-Deze site wordt bijgehouden door Yolijn van der Kolk (Frameless) en Jeroen du Chatinier (gemeente Utrecht).
+Deze site wordt bijgehouden door Yolijn van der Kolk (NL Design System) en Jeroen du Chatinier (gemeente Utrecht).
 
 ## Ik heb een idee of een vraag over deze site! Waar moet ik zijn?
 
-Maak een issue aan in de [Gebruikersonderzoeken GitHub](https://github.com/nl-design-system/gebruikersonderzoeken/issues) of stuur ons een mailtje.
+Maak een issue aan in de [Gebruikersonderzoeken GitHub](https://github.com/nl-design-system/gebruikersonderzoeken/issues) of stuur ons een mailtje op [info@nldesignsystem.nl](mailto:info@nldesignsystem.nl).

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -65,8 +65,8 @@ const config: Config = {
         {
           items: [
             {
-              href: 'mailto:yolijn@frameless.io',
-              label: 'Yolijn van der Kolk - yolijn@frameless.io',
+              href: 'mailto:info@nldesignsystem.nl',
+              label: 'NL Design System kernteam - info@nldesignsystem.nl',
             },
             {
               href: 'mailto:j.du.chatinier@utrecht.nl',


### PR DESCRIPTION
Nu we vanuit NL Design System tijd kunnen besteden aan gebruikersonderzoeken.nl is verzocht om het e-mail adres dat te laten reflecteren :) 

Het is daarbij denk ik handig dat we nldesignsystem.nl gebruiken en niet ictu.nl, dus daarom ben ik voor info@nldesignsystem.nl gegaan. Nog een voordeel is dat deze mailbox door meerdere kernteam leden in de gaten gehouden kan worden ✨ 