### PR TITLE
refactor: use zod library to create types and typeguards

### DIFF
--- a/packages/website/src/content.config.ts
+++ b/packages/website/src/content.config.ts
@@ -1,17 +1,20 @@
 import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders'; // Not available with legacy API
 
+export const CoverSchema = z.object({
+  alt: z.string(),
+  url: z.string(),
+});
+
+export const PageSchema = z.object({
+  cover: CoverSchema.optional(),
+  description: z.string().optional(),
+  title: z.string(),
+});
+
 const onderzoeken = defineCollection({
   loader: glob({ base: '../../docs/', pattern: '**/*.md' }),
-  schema: z.object({
-    cover: z
-      .object({
-        alt: z.string(),
-        url: z.string(),
-      })
-      .optional(),
-    title: z.string(),
-  }),
+  schema: PageSchema,
 });
 
 export const collections = { onderzoeken };

--- a/packages/website/src/layouts/default.astro
+++ b/packages/website/src/layouts/default.astro
@@ -1,17 +1,16 @@
 ---
-interface Cover {
-  url: string;
-  alt: string;
-}
+import { z } from 'astro:content';
+import { CoverSchema, PageSchema } from '../content.config.ts';
 
-interface Props {
-  description?: string;
-  cover?: Cover;
-  title?: string;
-}
+// Type is automatically determined based on schema!
+type Props = z.infer<typeof PageSchema>;
+type Cover = z.infer<typeof CoverSchema>;
 
-const isCover = (object: unknown): object is Cover =>
-  typeof (object as Cover)?.url === 'string' && typeof (object as Cover)?.alt === 'string';
+// Validates object ensuring it conforms to the Cover schema.
+const isCover = (maybeCover: unknown): maybeCover is Cover => {
+  const result = CoverSchema.safeParse(maybeCover);
+  return result.success;
+};
 
 const fallbackCover = {
   alt: 'Grafisch vergrootglas over document',
@@ -25,6 +24,8 @@ const title = `${pageTitle} | Gebruikersonderzoeken`;
 const description = pageDescription ?? 'Gedeelde gebruikersonderzoeken voor de overheid';
 const canonical = Astro.url.href;
 const cover = isCover(pageCover) ? pageCover : fallbackCover;
+
+console.log(cover);
 ---
 
 <html lang={lang} dir="ltr" class="ma-theme">


### PR DESCRIPTION
@petergoes ik zag dat je in de PR #359 gedeeltelijk gebruik maakt van zod om data validatie te doen, maar dat er dan een dubbele boekhouding is om types en typeguards te maken. 

Op basis van dit artikel https://4markdown.com/using-zod-and-typescript-to-write-type-safe-code/#Finding%20the%20Balance leek het me mogelijk (en niet al te moeilijk) om zod alle verantwoordelijkheid voor data validatie op zich te laten nemen. 

Hierbij mijn voorstel (nog wel in Astro, al jeuken mijn vingers om meer gewone TypeScript te kunnen gebruiken)