### PR TITLE
Prevent inline styles because of csp issues

### DIFF
--- a/packages/website/astro.config.ts
+++ b/packages/website/astro.config.ts
@@ -5,6 +5,9 @@ import { coverPlugin } from './remark-cover-plugin.ts';
 
 // https://astro.build/config
 export default defineConfig({
+  build: {
+    inlineStylesheets: 'never',
+  },
   integrations: [react()],
   markdown: {
     remarkPlugins: [coverPlugin],


### PR DESCRIPTION
Deze PR zorgt er voor dat Astro al de css in css files zet inplaats van inlined
