### PR TITLE
ci: deploy to `gh-pages` branch again

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,3 +49,9 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
         id: deploy-pages
+
+      - name: Continuous Deployment to GitHub Pages branch (for Plesk)
+        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 # v4.7.3
+        with:
+          branch: gh-pages
+          folder: build/


### PR DESCRIPTION
Nu we Plesk gaan gebruiken voor deze site, moeten we weer een build in `gh-pages` neerzetten.