### PR TITLE
Patch @utrecht/figure-css

### DIFF
--- a/patches/@utrecht__figure-css@1.5.1.patch
+++ b/patches/@utrecht__figure-css@1.5.1.patch
@@ -1,0 +1,9 @@
+diff --git a/dist/index.min.css b/dist/index.min.css
+index 62fbaa0e322cf5280c0905a339e640f777d32bca..45e3446aab4c236ac835cdacbfeb5a86bf5b392a 100644
+--- a/dist/index.min.css
++++ b/dist/index.min.css
+@@ -1 +1,2 @@
+-.utrecht-figure{margin-block-end:calc(var(--utrecht-space-around, 0)*var(--utrecht-figure-margin-block-end, 0));margin-block-start:calc(var(--utrecht-space-around, 0)*var(--utrecht-figure-margin-block-start, 0))}.utrecht-figure__caption{color:var(--utrecht-figure-caption-color);font-size:var(--utrecht-figure-caption-font-size);line-height:var(--utrecht-figure-caption-line-height)}
+\ No newline at end of file
++.utrecht-figure{margin-inline-end:calc(var(--utrecht-space-around, 0)*var(--utrecht-figure-margin-inline-end, 0));margin-inline-start:calc(var(--utrecht-space-around, 0)*var(--utrecht-figure-margin-inline-start, 0));margin-block-end:calc(var(--utrecht-space-around, 0)*var(--utrecht-figure-margin-block-end, 0));margin-block-start:calc(var(--utrecht-space-around, 0)*var(--utrecht-figure-margin-block-start, 0))}.utrecht-figure__caption{color:var(--utrecht-figure-caption-color);font-size:var(--utrecht-figure-caption-font-size);line-height:var(--utrecht-figure-caption-line-height)}
++

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@utrecht/figure-css@1.5.1':
+    hash: 514cfaaad630b6d574ce2f60c431d4d1667fbac0e5eea95026600743530d6422
+    path: patches/@utrecht__figure-css@1.5.1.patch
+
 importers:
 
   .:
@@ -183,7 +188,7 @@ importers:
         version: 1.5.1
       '@utrecht/figure-css':
         specifier: 1.5.1
-        version: 1.5.1
+        version: 1.5.1(patch_hash=514cfaaad630b6d574ce2f60c431d4d1667fbac0e5eea95026600743530d6422)
       '@utrecht/heading-group-css':
         specifier: 1.5.1
         version: 1.5.1
@@ -5611,7 +5616,7 @@ snapshots:
       '@utrecht/drawer-css': 1.4.1
       '@utrecht/emphasis-css': 1.5.1
       '@utrecht/fieldset-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/figure-css': 1.5.1
+      '@utrecht/figure-css': 1.5.1(patch_hash=514cfaaad630b6d574ce2f60c431d4d1667fbac0e5eea95026600743530d6422)
       '@utrecht/focus-ring-css': 2.3.1
       '@utrecht/form-field-checkbox-react': 1.0.10(@babel/runtime@7.27.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@utrecht/form-field-description-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -5719,7 +5724,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/figure-css@1.5.1': {}
+  '@utrecht/figure-css@1.5.1(patch_hash=514cfaaad630b6d574ce2f60c431d4d1667fbac0e5eea95026600743530d6422)': {}
 
   '@utrecht/focus-ring-css@2.3.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,14 @@
+packages:
+  - packages/**
+
 autoInstallPeers: false
-savePrefix: ""
 
 minimumReleaseAge: 1440
+
 minimumReleaseAgeExclude:
   - '@nl-design-system-community/ma-design-tokens'
 
-packages:
-  - "packages/**"
+patchedDependencies:
+  '@utrecht/figure-css@1.5.1': patches/@utrecht__figure-css@1.5.1.patch
+
+savePrefix: ''


### PR DESCRIPTION
Patches `@utrecht/figure-css` to give it a configurable `margin-block` via tokens
