### PR TITLE
chore: upgrade React (fixes CVE-2025-55182, CVE-2025-67779 and CVE-2025-55183)

### DIFF
--- a/packages/ma-components/package.json
+++ b/packages/ma-components/package.json
@@ -20,6 +20,6 @@
     "@utrecht/button-css": "2.3.1",
     "@utrecht/link-css": "1.6.1",
     "@utrecht/textbox-css": "2.0.0",
-    "react": "19.2.1"
+    "react": "19.2.3"
   }
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -77,8 +77,8 @@
     "hast-util-is-element": "3.0.0",
     "hast-util-select": "6.0.4",
     "postcss": "8.5.3",
-    "react": "19.2.1",
-    "react-dom": "19.2.1",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
     "unist-util-visit": "5.0.0",
     "vfile": "6.0.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         version: 9.0.0(typescript@5.8.3)
       prism-react-renderer:
         specifier: 2.4.1
-        version: 2.4.1(react@19.2.1)
+        version: 2.4.1(react@19.2.3)
       stylelint:
         specifier: 16.19.1
         version: 16.19.1(typescript@5.8.3)
@@ -103,8 +103,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
       react:
-        specifier: 19.2.1
-        version: 19.2.1
+        specifier: 19.2.3
+        version: 19.2.3
 
   packages/website:
     dependencies:
@@ -134,7 +134,7 @@ importers:
         version: 5.2.5
       '@gemeente-denhaag/descriptionlist':
         specifier: 4.0.1
-        version: 4.0.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 4.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@nl-design-system-candidate/data-badge-css':
         specifier: 1.0.2
         version: 1.0.2
@@ -143,19 +143,19 @@ importers:
         version: 1.1.0
       '@nl-design-system-candidate/heading-react':
         specifier: 1.1.2
-        version: 1.1.2(@babel/runtime@7.27.0)(react@19.2.1)
+        version: 1.1.2(@babel/runtime@7.27.0)(react@19.2.3)
       '@nl-design-system-candidate/link-css':
         specifier: 2.0.0
         version: 2.0.0
       '@nl-design-system-candidate/link-react':
         specifier: 1.1.3
-        version: 1.1.3(@babel/runtime@7.27.0)(react@19.2.1)
+        version: 1.1.3(@babel/runtime@7.27.0)(react@19.2.3)
       '@nl-design-system-candidate/paragraph-css':
         specifier: 2.1.0
         version: 2.1.0
       '@nl-design-system-candidate/paragraph-react':
         specifier: 2.1.2
-        version: 2.1.2(@babel/runtime@7.27.0)(react@19.2.1)
+        version: 2.1.2(@babel/runtime@7.27.0)(react@19.2.3)
       '@nl-design-system-candidate/skip-link-css':
         specifier: 1.0.3
         version: 1.0.3
@@ -182,7 +182,7 @@ importers:
         version: 1.3.1
       '@utrecht/component-library-react':
         specifier: 10.2.0
-        version: 10.2.0(@babel/runtime@7.27.0)(date-fns@2.30.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 10.2.0(@babel/runtime@7.27.0)(date-fns@2.30.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@utrecht/emphasis-css':
         specifier: 1.5.1
         version: 1.5.1
@@ -231,13 +231,13 @@ importers:
     devDependencies:
       '@astrojs/react':
         specifier: 4.3.0
-        version: 4.3.0(@types/node@22.15.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tsx@4.20.6)(yaml@2.7.1)
+        version: 4.3.0(@types/node@22.15.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.20.6)(yaml@2.7.1)
       '@nl-design-system/tsconfig':
         specifier: 1.0.3
         version: 1.0.3(typescript@5.8.3)
       '@tabler/icons-react':
         specifier: 3.34.0
-        version: 3.34.0(react@19.2.1)
+        version: 3.34.0(react@19.2.3)
       '@types/hast':
         specifier: 3.0.4
         version: 3.0.4
@@ -269,11 +269,11 @@ importers:
         specifier: 8.5.3
         version: 8.5.3
       react:
-        specifier: 19.2.1
-        version: 19.2.1
+        specifier: 19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: 19.2.1
-        version: 19.2.1(react@19.2.1)
+        specifier: 19.2.3
+        version: 19.2.3(react@19.2.3)
       unist-util-visit:
         specifier: 5.0.0
         version: 5.0.0
@@ -3647,10 +3647,10 @@ packages:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
 
-  react-dom@19.2.1:
-    resolution: {integrity: sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==}
+  react-dom@19.2.3:
+    resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
-      react: ^19.2.1
+      react: ^19.2.3
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -3659,8 +3659,8 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
-  react@19.2.1:
-    resolution: {integrity: sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==}
+  react@19.2.3:
+    resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
   read-pkg-up@7.0.1:
@@ -4555,13 +4555,13 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@4.3.0(@types/node@22.15.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tsx@4.20.6)(yaml@2.7.1)':
+  '@astrojs/react@4.3.0(@types/node@22.15.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.20.6)(yaml@2.7.1)':
     dependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react': 4.4.1(vite@6.3.5(@types/node@22.15.3)(tsx@4.20.6)(yaml@2.7.1))
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
       ultrahtml: 1.6.0
       vite: 6.3.5(@types/node@22.15.3)(tsx@4.20.6)(yaml@2.7.1)
     transitivePeerDependencies:
@@ -4907,11 +4907,11 @@ snapshots:
 
   '@fontsource/source-sans-pro@5.2.5': {}
 
-  '@gemeente-denhaag/descriptionlist@4.0.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@gemeente-denhaag/descriptionlist@4.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@humanfs/core@0.19.1': {}
 
@@ -5043,27 +5043,27 @@ snapshots:
 
   '@nl-design-system-candidate/heading-css@1.1.0': {}
 
-  '@nl-design-system-candidate/heading-react@1.1.2(@babel/runtime@7.27.0)(react@19.2.1)':
+  '@nl-design-system-candidate/heading-react@1.1.2(@babel/runtime@7.27.0)(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       clsx: 2.1.1
-      react: 19.2.1
+      react: 19.2.3
 
   '@nl-design-system-candidate/link-css@2.0.0': {}
 
-  '@nl-design-system-candidate/link-react@1.1.3(@babel/runtime@7.27.0)(react@19.2.1)':
+  '@nl-design-system-candidate/link-react@1.1.3(@babel/runtime@7.27.0)(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       clsx: 2.1.1
-      react: 19.2.1
+      react: 19.2.3
 
   '@nl-design-system-candidate/paragraph-css@2.1.0': {}
 
-  '@nl-design-system-candidate/paragraph-react@2.1.2(@babel/runtime@7.27.0)(react@19.2.1)':
+  '@nl-design-system-candidate/paragraph-react@2.1.2(@babel/runtime@7.27.0)(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       clsx: 2.1.1
-      react: 19.2.1
+      react: 19.2.3
 
   '@nl-design-system-candidate/skip-link-css@1.0.3': {}
 
@@ -5221,10 +5221,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tabler/icons-react@3.34.0(react@19.2.1)':
+  '@tabler/icons-react@3.34.0(react@19.2.3)':
     dependencies:
       '@tabler/icons': 3.34.0
-      react: 19.2.1
+      react: 19.2.3
 
   '@tabler/icons@3.34.0': {}
 
@@ -5526,60 +5526,60 @@ snapshots:
 
   '@utrecht/button-group-css@1.4.1': {}
 
-  '@utrecht/button-group-react@1.0.1(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/button-group-react@1.0.1(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/button-group-css': 1.4.1
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/button-link-css@1.3.1': {}
 
-  '@utrecht/button-react@2.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/button-react@2.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/button-css': 2.3.1
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/calendar-css@1.4.1': {}
 
-  '@utrecht/calendar-react@1.0.11(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/calendar-react@1.0.11(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
-      '@utrecht/button-react': 2.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/button-react': 2.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@utrecht/calendar-css': 1.4.1
       clsx: 2.1.1
       date-fns: 2.30.0
       lodash-es: 4.17.21
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/card-css@0.1.0':
     dependencies:
       '@utrecht/img-css': 1.3.1
 
-  '@utrecht/card-react@0.0.1(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/card-react@0.0.1(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/card-css': 0.1.0
-      '@utrecht/link-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/link-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/checkbox-css@1.6.1': {}
 
-  '@utrecht/checkbox-react@1.0.8(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/checkbox-react@1.0.8(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/checkbox-css': 1.6.1
       '@utrecht/custom-checkbox-css': 1.3.2
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/code-block-css@1.5.1': {}
 
@@ -5591,15 +5591,15 @@ snapshots:
 
   '@utrecht/combobox-css@1.4.1': {}
 
-  '@utrecht/combobox-react@0.0.8(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/combobox-react@0.0.8(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/combobox-css': 1.4.1
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
-  '@utrecht/component-library-react@10.2.0(@babel/runtime@7.27.0)(date-fns@2.30.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/component-library-react@10.2.0(@babel/runtime@7.27.0)(date-fns@2.30.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/accordion-css': 2.0.0
@@ -5613,36 +5613,36 @@ snapshots:
       '@utrecht/badge-status-css': 1.4.1
       '@utrecht/blockquote-css': 1.6.1
       '@utrecht/breadcrumb-nav-css': 1.5.0
-      '@utrecht/button-group-react': 1.0.1(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/button-group-react': 1.0.1(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@utrecht/button-link-css': 1.3.1
-      '@utrecht/button-react': 2.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@utrecht/calendar-react': 1.0.11(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/button-react': 2.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@utrecht/calendar-react': 1.0.11(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@utrecht/card-css': 0.1.0
-      '@utrecht/card-react': 0.0.1(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@utrecht/checkbox-react': 1.0.8(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/card-react': 0.0.1(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@utrecht/checkbox-react': 1.0.8(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@utrecht/code-block-css': 1.5.1
       '@utrecht/code-css': 1.5.1
       '@utrecht/color-sample-css': 1.4.1
       '@utrecht/column-layout-css': 1.5.1
-      '@utrecht/combobox-react': 0.0.8(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/combobox-react': 0.0.8(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@utrecht/currency-data-css': 1.3.1
       '@utrecht/custom-checkbox-css': 1.3.2
       '@utrecht/data-badge-css': 1.0.1
-      '@utrecht/data-badge-react': 1.0.4(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/data-badge-react': 1.0.4(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@utrecht/data-list-css': 1.4.1
       '@utrecht/data-placeholder-css': 1.4.1
       '@utrecht/digid-button-css': 1.4.1
       '@utrecht/document-css': 1.5.1
       '@utrecht/drawer-css': 1.4.1
       '@utrecht/emphasis-css': 1.5.1
-      '@utrecht/fieldset-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/fieldset-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@utrecht/figure-css': 1.5.1(patch_hash=514cfaaad630b6d574ce2f60c431d4d1667fbac0e5eea95026600743530d6422)
       '@utrecht/focus-ring-css': 2.3.1
-      '@utrecht/form-field-checkbox-react': 1.0.10(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@utrecht/form-field-description-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@utrecht/form-field-error-message-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@utrecht/form-field-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@utrecht/form-label-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/form-field-checkbox-react': 1.0.10(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@utrecht/form-field-description-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@utrecht/form-field-error-message-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@utrecht/form-field-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@utrecht/form-label-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@utrecht/form-toggle-css': 1.5.1
       '@utrecht/heading-1-css': 1.5.1
       '@utrecht/heading-2-css': 1.5.1
@@ -5658,10 +5658,10 @@ snapshots:
       '@utrecht/index-char-nav-css': 1.4.1
       '@utrecht/link-button-css': 1.4.1
       '@utrecht/link-list-css': 2.3.1
-      '@utrecht/link-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/link-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@utrecht/link-social-css': 1.4.1
       '@utrecht/list-social-css': 1.4.1
-      '@utrecht/listbox-react': 1.0.10(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/listbox-react': 1.0.10(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@utrecht/logo-button-css': 1.4.1
       '@utrecht/logo-css': 1.4.1
       '@utrecht/logo-image-css': 1.4.1
@@ -5674,7 +5674,7 @@ snapshots:
       '@utrecht/number-badge-css': 2.3.1
       '@utrecht/number-data-css': 1.4.1
       '@utrecht/open-forms-container-css': 1.0.1
-      '@utrecht/open-forms-container-react': 1.0.1(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/open-forms-container-react': 1.0.1(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@utrecht/ordered-list-css': 1.5.2
       '@utrecht/page-content-css': 1.4.1
       '@utrecht/page-css': 1.4.1
@@ -5684,7 +5684,7 @@ snapshots:
       '@utrecht/paragraph-css': 2.3.1
       '@utrecht/pre-heading-css': 1.4.1
       '@utrecht/preserve-data-css': 1.3.1
-      '@utrecht/radio-button-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/radio-button-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@utrecht/rich-text-css': 1.3.1
       '@utrecht/search-bar-css': 2.2.1
       '@utrecht/select-css': 1.8.1
@@ -5697,7 +5697,7 @@ snapshots:
       '@utrecht/table-css': 1.6.1
       '@utrecht/table-of-contents-css': 0.3.1
       '@utrecht/textarea-css': 2.3.2
-      '@utrecht/textbox-react': 1.0.8(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/textbox-react': 1.0.8(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@utrecht/top-task-link-css': 1.4.1
       '@utrecht/top-task-nav-css': 1.3.1
       '@utrecht/unordered-list-css': 1.5.1
@@ -5705,8 +5705,8 @@ snapshots:
       '@utrecht/vega-visualization-css': 1.4.1
       clsx: 2.1.1
       lodash.chunk: 4.2.0
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
       date-fns: 2.30.0
 
@@ -5716,13 +5716,13 @@ snapshots:
 
   '@utrecht/data-badge-css@1.0.1': {}
 
-  '@utrecht/data-badge-react@1.0.4(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/data-badge-react@1.0.4(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/data-badge-css': 1.0.1
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/data-list-css@1.4.1': {}
 
@@ -5736,71 +5736,71 @@ snapshots:
 
   '@utrecht/emphasis-css@1.5.1': {}
 
-  '@utrecht/fieldset-react@1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/fieldset-react@1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/form-fieldset-css': 1.5.1
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/figure-css@1.5.1(patch_hash=514cfaaad630b6d574ce2f60c431d4d1667fbac0e5eea95026600743530d6422)': {}
 
   '@utrecht/focus-ring-css@2.3.1': {}
 
-  '@utrecht/form-field-checkbox-react@1.0.10(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/form-field-checkbox-react@1.0.10(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
-      '@utrecht/checkbox-react': 1.0.8(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@utrecht/form-field-description-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@utrecht/form-field-error-message-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@utrecht/form-field-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@utrecht/form-label-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@utrecht/checkbox-react': 1.0.8(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@utrecht/form-field-description-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@utrecht/form-field-error-message-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@utrecht/form-field-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@utrecht/form-label-react': 1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/form-field-css@1.5.1': {}
 
   '@utrecht/form-field-description-css@1.5.1': {}
 
-  '@utrecht/form-field-description-react@1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/form-field-description-react@1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/form-field-description-css': 1.5.1
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/form-field-error-message-css@1.5.1': {}
 
-  '@utrecht/form-field-error-message-react@1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/form-field-error-message-react@1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/form-field-error-message-css': 1.5.1
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
-  '@utrecht/form-field-react@1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/form-field-react@1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/form-field-css': 1.5.1
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/form-fieldset-css@1.5.1': {}
 
   '@utrecht/form-label-css@1.6.1': {}
 
-  '@utrecht/form-label-react@1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/form-label-react@1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/form-label-css': 1.6.1
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/form-toggle-css@1.5.1': {}
 
@@ -5834,13 +5834,13 @@ snapshots:
 
   '@utrecht/link-list-css@2.3.1': {}
 
-  '@utrecht/link-react@1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/link-react@1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/link-css': 1.6.1
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/link-social-css@1.4.1': {}
 
@@ -5848,13 +5848,13 @@ snapshots:
 
   '@utrecht/listbox-css@1.5.2': {}
 
-  '@utrecht/listbox-react@1.0.10(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/listbox-react@1.0.10(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/listbox-css': 1.5.2
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/logo-button-css@1.4.1': {}
 
@@ -5883,13 +5883,13 @@ snapshots:
       '@utrecht/focus-ring-css': 2.3.1
       '@utrecht/textbox-css': 1.7.1
 
-  '@utrecht/open-forms-container-react@1.0.1(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/open-forms-container-react@1.0.1(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/open-forms-container-css': 1.0.1
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/ordered-list-css@1.5.2': {}
 
@@ -5913,13 +5913,13 @@ snapshots:
 
   '@utrecht/radio-button-css@1.6.1': {}
 
-  '@utrecht/radio-button-react@1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/radio-button-react@1.0.7(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/radio-button-css': 1.6.1
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/rich-text-css@1.3.1': {}
 
@@ -5951,13 +5951,13 @@ snapshots:
 
   '@utrecht/textbox-css@2.0.0': {}
 
-  '@utrecht/textbox-react@1.0.8(@babel/runtime@7.27.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@utrecht/textbox-react@1.0.8(@babel/runtime@7.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@utrecht/textbox-css': 1.7.1
       clsx: 2.1.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@utrecht/top-task-link-css@1.4.1': {}
 
@@ -8364,11 +8364,11 @@ snapshots:
 
   prettier@3.5.3: {}
 
-  prism-react-renderer@2.4.1(react@19.2.1):
+  prism-react-renderer@2.4.1(react@19.2.3):
     dependencies:
       '@types/prismjs': 1.26.5
       clsx: 2.1.1
-      react: 19.2.1
+      react: 19.2.3
 
   prismjs@1.30.0: {}
 
@@ -8413,16 +8413,16 @@ snapshots:
       iconv-lite: 0.6.3
       unpipe: 1.0.0
 
-  react-dom@19.2.1(react@19.2.1):
+  react-dom@19.2.3(react@19.2.3):
     dependencies:
-      react: 19.2.1
+      react: 19.2.3
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
 
   react-refresh@0.17.0: {}
 
-  react@19.2.1: {}
+  react@19.2.3: {}
 
   read-pkg-up@7.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,8 +20,8 @@ minimumReleaseAgeExclude:
   - '@nl-rvo/*'
   - '@rijkshuisstijl-community/*'
   - '@utrecht/*'
-  - 'react@19.2.1'
-  - 'react-dom@19.2.1'
+  - 'react@19.2.3'
+  - 'react-dom@19.2.3'
 
 patchedDependencies:
   '@utrecht/figure-css@1.5.1': patches/@utrecht__figure-css@1.5.1.patch


### PR DESCRIPTION
[More info](https://react.dev/blog/2025/12/11/denial-of-service-and-source-code-exposure-in-react-server-components)