### PR TITLE
docs: add algoritmewijzer onderzoek

### DIFF
--- a/docs/onderzoek-bekijken/1-formulieren/vng-online-formulieren.md
+++ b/docs/onderzoek-bekijken/1-formulieren/vng-online-formulieren.md
@@ -36,6 +36,8 @@ conducted_by:
 date_added: 2024-01-22
 ---
 
+<!-- @license CC0-1.0 -->
+
 # Contactformulier voor WMEBV
 
 - De toon en duidelijkheid van de tekst worden als prettig ervaren. In het formulier kunnen alle gebruikers goed volgen wat er moet gebeuren dankzij heldere knoppen en een overzichtelijke opmaak.

--- a/docs/onderzoek-bekijken/4-website-gebruik/logius-taalswitcher.md
+++ b/docs/onderzoek-bekijken/4-website-gebruik/logius-taalswitcher.md
@@ -32,6 +32,8 @@ conducted_by:
 date_added: 2025-05-02
 ---
 
+<!-- @license CC0-1.0 -->
+
 # Gebruik vertaaloptie op website (Taalswitch)
 
 ## Doel van het onderzoek

--- a/docs/onderzoek-bekijken/4-website-gebruik/utrecht-dark-mode.md
+++ b/docs/onderzoek-bekijken/4-website-gebruik/utrecht-dark-mode.md
@@ -29,6 +29,8 @@ type: kwantitatief onderzoek
 date_conducted: 2023-06-20
 ---
 
+<!-- @license CC0-1.0 -->
+
 # Dark mode gebruik op utrecht.nl
 
 ![Plaatje van een browser waar Google wordt getoond in Dark mode.](https://raw.githubusercontent.com/nl-design-system/gebruikersonderzoeken/assets/utrecht-dark-mode.png)

--- a/docs/onderzoek-bekijken/4-website-gebruik/utrecht-google-translate.md
+++ b/docs/onderzoek-bekijken/4-website-gebruik/utrecht-google-translate.md
@@ -29,6 +29,8 @@ type: kwantitatief onderzoek
 date_conducted: 2023-03-01
 ---
 
+<!-- @license CC0-1.0 -->
+
 # Google Translate gebruik op utrecht.nl
 
 ![Plaatje van een browser met waar de Google Translate pop-up getoond wordt om de pagina te gaan vertalen.](https://raw.githubusercontent.com/nl-design-system/gebruikersonderzoeken/assets/utrecht-google-translate.png)

--- a/docs/onderzoek-bekijken/4-website-gebruik/utrecht-lettertype.md
+++ b/docs/onderzoek-bekijken/4-website-gebruik/utrecht-lettertype.md
@@ -37,6 +37,8 @@ type: kwalitatief onderzoek, usability research
 date_conducted: 2025-05-01
 ---
 
+<!-- @license CC0-1.0 -->
+
 # Onderzoek lettertype bij neurodiversiteitsnetwerk
 
 ![Screenshot van de 'Paspoort en identiteitskaart aanvragen' pagina uit het prototype die gemaakt is met het lettertype Noto Sans.](https://raw.githubusercontent.com/nl-design-system/gebruikersonderzoeken/assets/utrecht-lettertype__prototype.png)

--- a/docs/onderzoek-bekijken/inovalor-algoritme-wijzer.md
+++ b/docs/onderzoek-bekijken/inovalor-algoritme-wijzer.md
@@ -20,6 +20,8 @@ date_added: 2026-01-16
 type: 1-10-100 methode
 ---
 
+<!-- @license CC0-1.0 -->
+
 # Gebruikersonderzoek Algoritmewijzer
 
 Om te begrijpen wat burgers willen weten over algoritmes en hoe zij daarover geïnformeerd willen worden, zijn verschillende gebruikersonderzoeken uitgevoerd. Het doel was om stap voor stap te ontdekken welke informatie relevant is, hoe die het best kan worden gepresenteerd, en hoe zowel burgers als organisaties de beeldtaal van de Algoritmewijzer ervaren.

--- a/docs/onderzoek-bekijken/tilburg-publicatieportaal.md
+++ b/docs/onderzoek-bekijken/tilburg-publicatieportaal.md
@@ -33,6 +33,8 @@ conducted_by:
 date_added: 2025-07-16
 ---
 
+<!-- @license CC0-1.0 -->
+
 # Gebruikersonderzoek Publicatievoorziening Wet open overheid
 
 ![Het design van het publicatieportaal van Tilburg](https://raw.githubusercontent.com/nl-design-system/gebruikersonderzoeken/assets/tilburg-publicatieportaal__design-publicatieportaal.jpeg)

--- a/docs/onderzoek-bekijken/utrecht-constateringsbrieven.md
+++ b/docs/onderzoek-bekijken/utrecht-constateringsbrieven.md
@@ -29,6 +29,8 @@ type: kwalitatief onderzoek, interviews
 date_conducted: 2025-02-01
 ---
 
+<!-- @license CC0-1.0 -->
+
 # Begrijpelijkheid constateringsbrieven Vergunningen, Toezicht en Handhaving
 
 _Onderzoek uitgevoerd in 2025 door de Gemeente Utrecht._

--- a/docs/onderzoek-bekijken/utrecht-initiatieven.md
+++ b/docs/onderzoek-bekijken/utrecht-initiatieven.md
@@ -30,6 +30,8 @@ conducted_by:
 date_added: 2023-06-01
 ---
 
+<!-- @license CC0-1.0 -->
+
 # Zichtbaarheid en toegankelijkheid initiatievenfonds
 
 _Onderzoek uitgevoerd in 2023 door de Stadskamer - Gemeente Utrecht_

--- a/docs/onderzoek-bekijken/utrecht-verhuisaangiften.md
+++ b/docs/onderzoek-bekijken/utrecht-verhuisaangiften.md
@@ -27,6 +27,8 @@ conducted_by:
 date_added: 2023-06-01
 ---
 
+<!-- @license CC0-1.0 -->
+
 # Uitzonderingen in het verhuisaangiften proces
 
 _Onderzoek uitgevoerd in 2023 door de Stadskamer - Gemeente Utrecht_

--- a/docs/onderzoek-delen/_onderzoek-template.md
+++ b/docs/onderzoek-delen/_onderzoek-template.md
@@ -36,6 +36,8 @@ target_group: ((niet verplicht - beschrijf de doelgroep voor het onderzoek))
 type: ((niet verplicht - beschrijf het type onderzoek))
 ---
 
+<!-- @license CC0-1.0 -->
+
 # ((Titel van het onderzoek hier))
 
 **Samengevat: ((Hier staat in één of twee zinnen superkort wat de conclusie is van het onderzoek, voor iemand die een korte blik werkt op de resultaten))**

--- a/docs/onderzoek-doen/README.md
+++ b/docs/onderzoek-doen/README.md
@@ -11,6 +11,8 @@ keywords:
   - doen
 ---
 
+<!-- @license CC0-1.0 -->
+
 # Gebruikersonderzoek, hoe kun je beginnen?
 
 Wil je gaan onderzoeken, maar weet je niet zo goed waar je moet beginnen? Of ben je al begonnen met het gebruikersonderzoek, maar kun je nog wat tips gebruiken?

--- a/docs/onderzoek-doen/checklist.md
+++ b/docs/onderzoek-doen/checklist.md
@@ -11,6 +11,8 @@ keywords:
   - Checklist
 ---
 
+<!-- @license CC0-1.0 -->
+
 # Checklist Gebruikersonderzoek
 
 Deze checklist kan gebruikt worden als hulpmiddel om je eigen gebruikersonderzoek mee te doen. Zoek je het stappenplan? Kijk dan op [gebruikersonderzoek doen](/docs/onderzoek-doen/).

--- a/docs/onderzoek-doen/toestemmingsformulier.md
+++ b/docs/onderzoek-doen/toestemmingsformulier.md
@@ -12,6 +12,8 @@ keywords:
   - gegevens delen
 ---
 
+<!-- @license CC0-1.0 -->
+
 # Toestemmingsformulier
 
 Hartelijk dank voor jouw deelname aan het gebruikersonderzoek.


### PR DESCRIPTION
Inovalor heeft het onderzoek toegevoegd via een GitHub issue https://github.com/nl-design-system/gebruikersonderzoeken/issues/554

Ik heb de volgorde iets aangepast en wat uitkomsten extra naar boven verplaatst zodat het de volgorde van [de template](https://github.com/nl-design-system/gebruikersonderzoeken/blob/main/docs/onderzoek-delen/_onderzoek-template.md) volgt.