### PR TITLE
ci: re-add id-token permission to GitHub pages deploy workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write # required to retrieve an OIDC token for actions/deploy-pages
       pages: write
 
     steps:
@@ -65,7 +66,7 @@ jobs:
 
     permissions:
       contents: read
-      id-token: write
+      id-token: write # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Apparently, actions/deploy-pages also uses OIDC to authenticate: https://github.com/actions/deploy-pages/issues/329#issuecomment-2030446649
