### PR TITLE
feat: add links to planned research discussions

### DIFF
--- a/docs/onderzoek-doen/README.md
+++ b/docs/onderzoek-doen/README.md
@@ -36,6 +36,8 @@ Door met een onderzoekspartner samen te werken kun je nog eens naar je onderzoek
 
 Dat kan iemand zijn met wie je een goede klik hebt. Een directe collega, iemand van een hele andere afdeling of zelfs iemand van een andere organisatie. Zolang jullie maar dezelfde vraag hebben.
 
+**Tip**: [Kijk bij aankomende onderzoeken](https://github.com/nl-design-system/gebruikersonderzoeken/discussions/categories/aankomend-gepland-onderzoek) of iemand al aan een vergelijkbaar onderwerp werkt. Zo voorkom je dubbel werk en vind je misschien een onderzoekspartner. Staat er nog geen vergelijkbaar onderzoek tussen? Kondig dan je eigen geplande onderzoek aan, zodat anderen kunnen aanhaken.
+
 ## Stap 2: De onderzoeksvraag
 
 Voor dit stappenplan nemen we een observatieonderzoek als voorbeeld: Je geeft iemand een opdracht, kijkt wat die persoon doet en ontdek wat er wel en niet werkt.

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -44,7 +44,7 @@ const recentOnderzoekenTop3 = recentOnderzoeken.toSpliced(3, Infinity);
     heading="Plannen voor gebruikersonderzoek?"
     content="Kondig je geplande onderzoek aan in community en ontdek wie aan hetzelfde onderwerp werkt. Zo kun je ervaringen uitwisselen of samenwerken."
     footerActions={[
-      { href: 'https://github.com/nl-design-system/gebruikersonderzoeken/discussions', label: 'Kondig onderzoek aan' },
+      { href: 'https://github.com/nl-design-system/gebruikersonderzoeken/discussions/categories/aankomend-gepland-onderzoek', label: 'Kondig onderzoek aan' },
     ]}
   />
 

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -41,10 +41,10 @@ const recentOnderzoekenTop3 = recentOnderzoeken.toSpliced(3, Infinity);
   </PageSection>
 
   <BannerUpdate
-    heading="Staat er een gebruikersonderzoek op de planning?"
-    content="Deel je geplande onderzoek met de community en ontdek wie aan hetzelfde onderwerp werkt. Zo kun je ervaringen uitwisselen of samenwerken."
+    heading="Plannen voor gebruikersonderzoek?"
+    content="Kondig je geplande onderzoek aan in community en ontdek wie aan hetzelfde onderwerp werkt. Zo kun je ervaringen uitwisselen of samenwerken."
     footerActions={[
-      { href: 'https://github.com/nl-design-system/gebruikersonderzoeken/discussions', label: 'Deel je geplande onderzoek' },
+      { href: 'https://github.com/nl-design-system/gebruikersonderzoeken/discussions', label: 'Kondig onderzoek aan' },
     ]}
   />
 

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -44,7 +44,10 @@ const recentOnderzoekenTop3 = recentOnderzoeken.toSpliced(3, Infinity);
     heading="Plannen voor gebruikersonderzoek?"
     content="Kondig je geplande onderzoek aan in community en ontdek wie aan hetzelfde onderwerp werkt. Zo kun je ervaringen uitwisselen of samenwerken."
     footerActions={[
-      { href: 'https://github.com/nl-design-system/gebruikersonderzoeken/discussions/categories/aankomend-gepland-onderzoek', label: 'Kondig onderzoek aan' },
+      {
+        href: 'https://github.com/nl-design-system/gebruikersonderzoeken/discussions/categories/aankomend-gepland-onderzoek',
+        label: 'Kondig onderzoek aan',
+      },
     ]}
   />
 

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -40,6 +40,14 @@ const recentOnderzoekenTop3 = recentOnderzoeken.toSpliced(3, Infinity);
     <CardListOnderzoek headingLevels={3} onderzoeken={recentOnderzoekenTop3} />
   </PageSection>
 
+  <BannerUpdate
+    heading="Staat er een gebruikersonderzoek op de planning?"
+    content="Deel je geplande onderzoek met de community en ontdek wie aan hetzelfde onderwerp werkt. Zo kun je ervaringen uitwisselen of samenwerken."
+    footerActions={[
+      { href: 'https://github.com/nl-design-system/gebruikersonderzoeken/discussions', label: 'Deel je geplande onderzoek' },
+    ]}
+  />
+
   <PageSection withSpace>
     <Heading level={2}>Thema's</Heading>
     <CardListTheme headingLevels={3} columns={2} themes={sortedThemes} />


### PR DESCRIPTION
Op 2 plekken zijn er verwijzingen naar aankomende onderzoeken toegevoegd:

- Op de homepage een call-to-action toegevoegd om geplande gebruikersonderzoeken via Discussions zichtbaar te maken.
- Op de pagina Onderzoek doen een tip toegevoegd om eerst vergelijkbare onderzoeken te bekijken en, als die er nog niet zijn, een eigen gepland onderzoek aan te kondigen.