### PR TITLE
chore: upgrade npm-check-updates to 22

### DIFF
--- a/.ncurc.major.mjs
+++ b/.ncurc.major.mjs
@@ -1,6 +1,6 @@
-const minorConfig = require('./.ncurc.minor.cjs');
+import minorConfig from './.ncurc.minor.mjs';
 
-module.exports = {
+export default {
   ...minorConfig,
   reject: [
     ...minorConfig.reject,

--- a/.ncurc.minor.mjs
+++ b/.ncurc.minor.mjs
@@ -1,6 +1,6 @@
-const patchConfig = require('./.ncurc.patch.cjs');
+import patchConfig from './.ncurc.patch.mjs';
 
-module.exports = {
+export default {
   ...patchConfig,
   reject: [...patchConfig.reject],
   target: 'minor',

--- a/.ncurc.patch.mjs
+++ b/.ncurc.patch.mjs
@@ -1,5 +1,4 @@
-module.exports = {
-  cooldown: 1, // 1 day
+export default {
   dep: ['dev', 'prod'],
   install: 'always',
   reject: [],

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "test-update": "pnpm run --if-present lint && pnpm run --if-present test && pnpm run --if-present build && pnpm run --if-present lint-build && pnpm run --if-present test-build",
     "prettier": "prettier --write .",
     "typecheck": "pnpm --recursive run typecheck",
-    "update-patch": "npm-check-updates --configFileName .ncurc.patch.cjs",
-    "update-minor": "npm-check-updates --configFileName .ncurc.minor.cjs",
-    "update-major": "npm-check-updates --configFileName .ncurc.major.cjs"
+    "update-patch": "npm-check-updates --configFileName .ncurc.patch.mjs",
+    "update-minor": "npm-check-updates --configFileName .ncurc.minor.mjs",
+    "update-major": "npm-check-updates --configFileName .ncurc.major.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "2.29.8",
@@ -53,7 +53,7 @@
     "globals": "16.5.0",
     "husky": "9.1.7",
     "lint-staged": "16.2.7",
-    "npm-check-updates": "19.3.2",
+    "npm-check-updates": "22.2.9",
     "npm-package-json-lint": "9.1.0",
     "prettier": "3.8.1",
     "prettier-plugin-astro": "0.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: 16.2.7
         version: 16.2.7
       npm-check-updates:
-        specifier: 19.3.2
-        version: 19.3.2
+        specifier: 22.2.9
+        version: 22.2.9
       npm-package-json-lint:
         specifier: 9.1.0
         version: 9.1.0(typescript@5.9.3)
@@ -3184,6 +3184,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@utrecht/accordion-css@3.0.1':
     resolution: {integrity: sha512-BWqGNjsJKzZ468gNbicMNyNoAwEAdN6msViCGURrW/tIsWRqoIcck3CozGuWdS9u7pakasfi6hhHvPbXcz4CoA==}
@@ -5481,9 +5482,9 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
-  npm-check-updates@19.3.2:
-    resolution: {integrity: sha512-9rr3z7znFjCSuaFxHGTFR2ZBOvLWaJcpLKmIquoTbDBNrwAGiHhv4MZyty6EJ9Xo/aMn35+2ISPSMgWIXx5Xkg==}
-    engines: {node: '>=20.0.0', npm: '>=8.12.1'}
+  npm-check-updates@22.2.9:
+    resolution: {integrity: sha512-DVeZ0KirHfliSsHuR2o7cHE+tW439sVHfJjF6cGWeDiY0Wyl3BI/jS4zV0eixtcMOquFbcF1Su/FsxOvk5MoYA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10.0.0'}
     hasBin: true
 
   npm-package-json-lint@9.1.0:
@@ -6604,6 +6605,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -12162,7 +12164,7 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
-  npm-check-updates@19.3.2: {}
+  npm-check-updates@22.2.9: {}
 
   npm-package-json-lint@9.1.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Since v21 there is ESM support; updated config accordingly.

Since v20 the cooldown is taken from pnpm config; removed cooldown from ncu config.
