### PR TITLE
chore: add client to card and data summary

### DIFF
--- a/docs/onderzoek-bekijken/2-mijn-zaken/vng-mijn-plan.md
+++ b/docs/onderzoek-bekijken/2-mijn-zaken/vng-mijn-plan.md
@@ -34,6 +34,8 @@ conducted_by:
   - VNG
   - Acato
 date_added: '2026-04-08'
+client:
+  - VNG
 ---
 
 <!-- @license CC0-1.0 -->

--- a/docs/onderzoek-bekijken/8-navigatie/rvo-navigatie.md
+++ b/docs/onderzoek-bekijken/8-navigatie/rvo-navigatie.md
@@ -43,6 +43,8 @@ conducted_by:
   - Deloitte
   - RVO
 date_added: '2025-04-17'
+client:
+  - RVO
 ---
 
 <!-- @license CC0-1.0 -->

--- a/docs/onderzoek-bekijken/gbbo-toptaken.md
+++ b/docs/onderzoek-bekijken/gbbo-toptaken.md
@@ -26,11 +26,15 @@ themes:
   - navigatie
   - gedrag-en-conversie
 conducted_by:
-  - GBBO in opdracht van Gemeente Zeewolde, Gemeente Ermelo en Gemeente Harderwijk
+  - GBBO
 date_added: '2026-01-23'
 date_conducted: '2019-11-27'
 target_group: Leden van het burgerpanel van gemeente Zeewolde (1.100 leden) en medewerkers van de gemeenten Ermelo en Harderwijk
 type: Vergelijkend taakprestatieonderzoek
+client:
+  - Gemeente Zeewolde
+  - Gemeente Ermelo
+  - Gemeente Harderwijk
 ---
 
 <!-- @license CC0-1.0 -->

--- a/docs/onderzoek-bekijken/kadaster-toetsenbordbesturing-kaart.md
+++ b/docs/onderzoek-bekijken/kadaster-toetsenbordbesturing-kaart.md
@@ -33,6 +33,8 @@ date_added: '2026-04-01'
 date_conducted: '2026-02-27'
 target_group: Mensen die geen muis kunnen gebruiken en afhankelijk zijn van toetsenbord, spraakbesturing of screenreader
 type: Interviews
+client:
+  - Kadaster
 ---
 
 <!-- @license CC0-1.0 -->
@@ -232,15 +234,21 @@ De inzichten uit dit onderzoek hebben onder andere waarde voor:
 
 ## Contactinformatie
 
+Kadaster:
+
+- https://www.kadaster.nl
+- https://www.generiekegeocomponenten.nl
+- [ggc@kadaster.nl](mailto:ggc@kadaster.nl)
+
 Valsplat:
 
 - https://valsplat.nl/nl/
-- hello@valsplat.nl
+- [hello@valsplat.nl](mailto:hello@valsplat.nl)
 
 Happy Labs:
 
 - https://happylabs.nl/nl/
-- hello@happylabs.nl
+- [hello@happylabs.nl](mailto:hello@happylabs.nl)
 
 ## Bijlagen
 

--- a/packages/website/src/components/card-list-onderzoek/card-list-onderzoek.tsx
+++ b/packages/website/src/components/card-list-onderzoek/card-list-onderzoek.tsx
@@ -16,7 +16,11 @@ export function CardListOnderzoek(props: PropsWithChildren<CardListThemeProps>) 
   return (
     <CardList>
       {props.onderzoeken.map((onderzoek) => {
-        const client = onderzoek.data.client && onderzoek.data.client.join(', ');
+        const client = onderzoek.data?.client?.reduce((string, part, index, list) => {
+          if (index === 0) return part
+          if (index === list.length - 1) `${string} en ${part}`
+          return `${string}, ${part}`
+        }, '')
         const conducted_by = onderzoek.data.conducted_by && onderzoek.data.conducted_by.join(', ');
 
         const metadata =

--- a/packages/website/src/components/card-list-onderzoek/card-list-onderzoek.tsx
+++ b/packages/website/src/components/card-list-onderzoek/card-list-onderzoek.tsx
@@ -16,7 +16,17 @@ export function CardListOnderzoek(props: PropsWithChildren<CardListThemeProps>) 
   return (
     <CardList>
       {props.onderzoeken.map((onderzoek) => {
-        const metadata = onderzoek.data.conducted_by ? [{ label: onderzoek.data.conducted_by.join(', ') }] : undefined;
+        const client = onderzoek.data.client && onderzoek.data.client.join(', ');
+        const conducted_by = onderzoek.data.conducted_by && onderzoek.data.conducted_by.join(', ');
+
+        const metadata =
+          client && conducted_by
+            ? [{ label: `Uitgevoerd door ${conducted_by} in opdracht van ${client}` }]
+            : client
+              ? [{ label: `In opdracht van ${client}` }]
+              : conducted_by
+                ? [{ label: `Uitgevoerd door ${conducted_by}` }]
+                : undefined;
 
         return (
           <CardAsLink

--- a/packages/website/src/components/card-list-onderzoek/card-list-onderzoek.tsx
+++ b/packages/website/src/components/card-list-onderzoek/card-list-onderzoek.tsx
@@ -11,17 +11,22 @@ export interface CardListThemeProps {
   onderzoeken: CollectionEntry<'onderzoeken'>[];
 }
 
+const concatNames = (list: string[] | undefined) =>
+  list
+    ? list.reduce((string, part, index, list) => {
+        if (index === 0) return part;
+        if (index === list.length - 1) return `${string} en ${part}`;
+        return `${string}, ${part}`;
+      }, '')
+    : list;
+
 export function CardListOnderzoek(props: PropsWithChildren<CardListThemeProps>) {
   const headingLevels = props.headingLevels || 2;
   return (
     <CardList>
       {props.onderzoeken.map((onderzoek) => {
-        const client = onderzoek.data?.client?.reduce((string, part, index, list) => {
-          if (index === 0) return part
-          if (index === list.length - 1) `${string} en ${part}`
-          return `${string}, ${part}`
-        }, '')
-        const conducted_by = onderzoek.data.conducted_by && onderzoek.data.conducted_by.join(', ');
+        const client = concatNames(onderzoek.data?.client);
+        const conducted_by = concatNames(onderzoek.data?.conducted_by);
 
         const metadata =
           client && conducted_by

--- a/packages/website/src/content.config.ts
+++ b/packages/website/src/content.config.ts
@@ -7,6 +7,7 @@ import { z } from 'astro/zod';
 const onderzoeken = defineCollection({
   loader: glob({ base: '../../docs/onderzoek-bekijken/', pattern: '**/!(_)(*).md' }),
   schema: z.object({
+    client: z.array(z.string()).optional(),
     conducted_by: z.array(z.string()).optional(),
     cover: CoverSchema.optional(),
     date_added: z.iso.date().default('2000-01-01'),

--- a/packages/website/src/pages/docs/onderzoek-bekijken/[...id].astro
+++ b/packages/website/src/pages/docs/onderzoek-bekijken/[...id].astro
@@ -74,7 +74,6 @@ const dataSummary = [
   .filter((item) => item.detail)
   .map(({ detail, title }) => ({ detail: Array.isArray(detail) ? detail.join(', ') : detail, title }));
 
-console.log('dataSummary', dataSummary);
 
 const tocItems: TableOfContentsItem[] = headings
   .filter((heading) => heading.depth === 2)

--- a/packages/website/src/pages/docs/onderzoek-bekijken/[...id].astro
+++ b/packages/website/src/pages/docs/onderzoek-bekijken/[...id].astro
@@ -74,7 +74,6 @@ const dataSummary = [
   .filter((item) => item.detail)
   .map(({ detail, title }) => ({ detail: Array.isArray(detail) ? detail.join(', ') : detail, title }));
 
-
 const tocItems: TableOfContentsItem[] = headings
   .filter((heading) => heading.depth === 2)
   .map((heading) => ({ href: `#${heading.slug}`, label: heading.text }));

--- a/packages/website/src/pages/docs/onderzoek-bekijken/[...id].astro
+++ b/packages/website/src/pages/docs/onderzoek-bekijken/[...id].astro
@@ -66,12 +66,15 @@ function formatDate(date: unknown) {
 
 const dataSummary = [
   { detail: formatDate(onderzoek.data.date_conducted), title: 'Datum onderzoek' },
+  { detail: onderzoek.data.client, title: 'Opdrachtgever' },
   { detail: onderzoek.data.conducted_by, title: 'Uitgevoerd door' },
   { detail: onderzoek.data.type, title: 'Type onderzoek' },
   { detail: onderzoek.data.target_group, title: 'Doelgroep' },
 ]
   .filter((item) => item.detail)
   .map(({ detail, title }) => ({ detail: Array.isArray(detail) ? detail.join(', ') : detail, title }));
+
+console.log('dataSummary', dataSummary);
 
 const tocItems: TableOfContentsItem[] = headings
   .filter((heading) => heading.depth === 2)


### PR DESCRIPTION
We kregen het verzoek van Kadaster om de opdrachtgever toe te voegen aan het onderzoek. Nu kwam hij nog niet goed naar boven wanneer ik dat deed. Daarom heb ik nu ook de support voor 'client' toegevoegd in deze PR.

De paar onderzoeken waar specifiek opdrachtgever werd genoemd die afweek van de conducted_by heb ik ook gelijk meegenomen.