### PR TITLE
chore: move vercel configuration to vercel.json

### DIFF
--- a/packages/website/vercel.json
+++ b/packages/website/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm run build",
-  "framework": "astro",
+  "framework": null,
   "outputDirectory": "dist",
   "git": {
     "deploymentEnabled": {

--- a/packages/website/vercel.json
+++ b/packages/website/vercel.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "cd ../.. && pnpm run build",
+  "framework": "astro",
+  "outputDirectory": "dist",
+  "git": {
+    "deploymentEnabled": {
+      "dependabot/*": false,
+      "gh-pages": false,
+      "assets": false
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "git": {
-    "deploymentEnabled": {
-      "assets": false
-    }
-  }
-}


### PR DESCRIPTION
This PR moves the vercel configuration to `vercel.json`.

It is part of an effort to have all vercel configuration in Terraform.  Some settings should "move with the code" and these will be kept in `vercel.json`.
