### PR TITLE
chore: configure prettier to format pnpm-workspace.yaml the same as pnpm CLI does

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,9 +19,6 @@ CODEOWNERS
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
-# pnpm using `pnpm config` is particular about the formatting of its workspace file
-pnpm-workspace.yaml
-
 
 # Ignore generated files from Stencil
 components/components.d.ts

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -32,5 +32,12 @@ export default {
         parser: 'astro',
       },
     },
+    {
+      // match pnpm CLI-driven changes behavior
+      files: ['pnpm-workspace.yaml'],
+      options: {
+        singleQuote: true,
+      },
+    },
   ],
 };


### PR DESCRIPTION
For YAML files, we use double quotes for strings.  We make an exception for the `pnpm-workspace.yaml` file, because the pnpm CLI uses single quotes.
